### PR TITLE
Bug fix; IL splits for Glitch and Warp levels; Death count pause option

### DIFF
--- a/LiveSplit.SuperMeatBoy.asl
+++ b/LiveSplit.SuperMeatBoy.asl
@@ -3,6 +3,7 @@
 //   Thermospore: displays, DE splits
 //        zment4: display framework
 //      6DPSMETA: IW splits
+//         rJade: suggestions, bug reports
 // SMB community: feedback, bug reports
 // ------------------------------------
 
@@ -50,6 +51,8 @@ startup
 	}
 	
 	settings.Add("deathDisp", false, "Death count display");
+	settings.Add("deathDisp_Pause", true, "Pause death count when run ends", "deathDisp");
+	settings.SetToolTip("deathDisp_Pause", "Prevents post-run deaths from getting into your death count (ex: Escape deaths during credits).\nDeath counting resumes when the timer is reset");
 	
 	settings.Add("ilDisp", false, "Last IL Time display");
 	settings.SetToolTip("ilDisp", "Times are truncated to 3 places (The game shows times rounded to two)");
@@ -172,6 +175,11 @@ update
 	if (
 		settings["deathDisp"]
 		&& current.deathCount > old.deathCount
+		&& (
+			timer.CurrentPhase != TimerPhase.Ended // The run must not be finished
+			|| !settings["deathDisp_Pause"]        // Or the setting must be disabled
+		)
+		
 	)
 	{
 		vars.SetTextComponent("Deaths", (current.deathCount - vars.deathCountOffset).ToString());

--- a/LiveSplit.SuperMeatBoy.asl
+++ b/LiveSplit.SuperMeatBoy.asl
@@ -310,15 +310,11 @@ split
 		if (
 			current.uiState == 0 // State: inside a level
 			&& (
-				(
-					current.lvlType == 2 // Type: in a bandage warp zone
-					&& old.lvlType != 2
-				)
-				|| (
-					current.lvlType == 3 // Type: in a character warp zone
-					&& old.lvlType != 3
-				)
+				old.lvlType == 0 // Type: light level
+				|| old.lvlType == 1 // Type: dark level
 			)
+			&& current.lvlType >= 2 // Types: warp zones
+			&& current.lvlType <= 5
 		)
 		{
 			return true;

--- a/LiveSplit.SuperMeatBoy.asl
+++ b/LiveSplit.SuperMeatBoy.asl
@@ -1,6 +1,6 @@
 // ---------------Credits--------------
-//            -7: creator
-//   Thermospore: displays, DE splits
+//            -7: creator, developer
+//   Thermospore: developer
 //        zment4: display framework
 //      6DPSMETA: IW splits
 //         rJade: suggestions, bug reports

--- a/LiveSplit.SuperMeatBoy.asl
+++ b/LiveSplit.SuperMeatBoy.asl
@@ -113,7 +113,7 @@ init
 		break;
 	}
 	
-	// Code to execute on startup
+	// Code to execute on timer start
 	vars.timer_OnStart = (EventHandler)((s, e) =>
 	{
 		// Set death count normalization on timer start

--- a/LiveSplit.SuperMeatBoy.asl
+++ b/LiveSplit.SuperMeatBoy.asl
@@ -292,12 +292,15 @@ split
 			return true;
 		}
 		
-		// When using keyboard "S" to exit to map
+		// When finishing a level that boots you out to map
 		if (
 			current.levelTransition == 1
 			&& old.levelTransition == 0
 			&& current.uiState == 0 // State: inside a level
-			&& current.playing == 0
+			&& ( // Check if level has been beaten
+				current.ILTime != 100000000 // Changes to IL time when lvl beaten
+				|| old.playing == 0 // Used in case replay was entered
+			)
 		)
 		{
 			return true;

--- a/LiveSplit.SuperMeatBoy.asl
+++ b/LiveSplit.SuperMeatBoy.asl
@@ -303,15 +303,18 @@ split
 			return true;
 		}
 		
-		// When entering a warp zone
+		// When entering a warp zone from inside a level
 		if (
-			(
-				current.lvlType == 2 // Type: in a bandage warp zone
-				&& old.lvlType != 2
-			)
-			|| (
-				current.lvlType == 3 // Type: in a character warp zone
-				&& old.lvlType != 3
+			current.uiState == 0 // State: inside a level
+			&& (
+				(
+					current.lvlType == 2 // Type: in a bandage warp zone
+					&& old.lvlType != 2
+				)
+				|| (
+					current.lvlType == 3 // Type: in a character warp zone
+					&& old.lvlType != 3
+				)
 			)
 		)
 		{

--- a/LiveSplit.SuperMeatBoy.asl
+++ b/LiveSplit.SuperMeatBoy.asl
@@ -23,6 +23,7 @@ state("SuperMeatBoy", "ogversion")
 	byte uiState         : "SuperMeatBoy.exe", 0x2d5ea0, 0x8d4;
 	byte levelTransition : "SuperMeatBoy.exe", 0x2d5ea8;
 	uint fetus           : "SuperMeatBoy.exe", 0x2d64bc, 0x10c;
+	int lvlType          : "SuperMeatBoy.exe", 0x2d54bc, 0x1ac;
 }
 
 state ("SuperMeatBoy", "1.2.5")
@@ -297,6 +298,21 @@ split
 			&& old.levelTransition == 0
 			&& current.uiState == 0 // State: inside a level
 			&& current.playing == 0
+		)
+		{
+			return true;
+		}
+		
+		// When entering a warp zone
+		if (
+			(
+				current.lvlType == 2 // Type: in a bandage warp zone
+				&& old.lvlType != 2
+			)
+			|| (
+				current.lvlType == 3 // Type: in a character warp zone
+				&& old.lvlType != 3
+			)
 		)
 		{
 			return true;

--- a/LiveSplit.SuperMeatBoy.asl
+++ b/LiveSplit.SuperMeatBoy.asl
@@ -319,6 +319,20 @@ split
 		{
 			return true;
 		}
+		
+		// When exiting to map from a warp or glitch level
+		// **still need to restrict to level completion, not just exit**
+		if (
+			(
+				current.lvlType == 0 // Type: light overworld
+				|| current.lvlType == 1 // Type: dark overworld
+			)
+			&& old.lvlType >= 2 // Types: warp zones, glitch level
+			&& old.lvlType <= 6
+		)
+		{
+			return true;
+		}
 	}
 	
 	// Boss entrance splits

--- a/LiveSplit.SuperMeatBoy.asl
+++ b/LiveSplit.SuperMeatBoy.asl
@@ -292,7 +292,8 @@ split
 			return true;
 		}
 		
-		// When finishing a level that boots you out to map
+		// When finishing a light/dark level that boots you out to map
+		// ie: X-20 levels, dark levels where you don't have the next level unlocked, etc.
 		if (
 			current.levelTransition == 1
 			&& old.levelTransition == 0
@@ -306,14 +307,14 @@ split
 			return true;
 		}
 		
-		// When entering a warp zone from inside a level
+		// When entering a warp level from inside a light/dark level
 		if (
 			current.uiState == 0 // State: inside a level
 			&& (
 				old.lvlType == 0 // Type: light level
 				|| old.lvlType == 1 // Type: dark level
 			)
-			&& current.lvlType >= 2 // Types: warp zones
+			&& current.lvlType >= 2 // Types: warp levels
 			&& current.lvlType <= 5
 		)
 		{
@@ -327,7 +328,7 @@ split
 				current.lvlType == 0 // Type: light overworld
 				|| current.lvlType == 1 // Type: dark overworld
 			)
-			&& old.lvlType >= 2 // Types: warp zones, glitch level
+			&& old.lvlType >= 2 // Types: warp levels, glitch level
 			&& old.lvlType <= 6
 		)
 		{


### PR DESCRIPTION
Fixed buggy IL split on light/dark levels that force you out to map upon completion (eg: X-20 levels, omega, reaching a dark level that is still locked, etc)